### PR TITLE
Always delete `key` entry if cache needs resetting

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const cacheFile = (client, filename, dir, fn) => {
           // so delete key hash and start over
           if (!compiledStr) {
             debug(`key hash existed for ${filename} but its str was missing`);
-            client.del(keyHash, err => {
+            client.del(key, err => {
               if (err) return fn(err);
               debug(`deleted existing key for ${filename} and re-creating`);
               cacheFile(client, filename, dir, fn);


### PR DESCRIPTION
I'm probably missing something as I've just done a cursory reading of the code, but if `client.get(keyHash)` doesn't return anything, I think we should be deleting `key` not `keyHash`.